### PR TITLE
Revise Makefile：Add `deploy` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ anvil :; anvil -m 'test test test test test test test test test test test junk' 
 
 zk-anvil :; npx zksync-cli dev start
 
+deploy:
+	@forge script script/DeployFundMe.s.sol:DeployFundMe $(NETWORK_ARGS)
+
 NETWORK_ARGS := --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast
 
 ifeq ($(findstring --network sepolia,$(ARGS)),--network sepolia)


### PR DESCRIPTION
## Summary
This Pull Request adds a `deploy` target to the Makefile, which was missing in the previous version. The absence of this target caused the `make deploy` command to fail.

## Changes Made
- Added the following `deploy` target to the Makefile:
  ```makefile
  deploy:
      @forge script script/DeployFundMe.s.sol:DeployFundMe $(NETWORK_ARGS)