### PR TITLE
remove unused AggregatorV3Interface import interface

### DIFF
--- a/test/mock/MockV3Aggregator.sol
+++ b/test/mock/MockV3Aggregator.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
-
 /**
  * @title MockV3Aggregator
  * @notice Based on the FluxAggregator contract
@@ -11,7 +9,7 @@ import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/Ag
  * aggregator contract, but how the aggregator got
  * its answer is unimportant
  */
-contract MockV3Aggregator is AggregatorV3Interface {
+contract MockV3Aggregator {
     uint256 public constant version = 4;
 
     uint8 public decimals;


### PR DESCRIPTION
remove import `AggregatorV3Interface` from mock contract since import `AggregatorV3Interface` cause error because interface doesn't exists in `chainlink-brownie-contracts/tree/main/contracts/src/v0.8/interfaces` 