### PR TITLE
Update Makefile for latest forge version argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install cyfrin/foundry-devops@0.2.2 --no-commit && forge install smartcontractkit/chainlink-brownie-contracts@1.1.1 --no-commit && forge install foundry-rs/forge-std@v1.8.2 --no-commit
+install :; forge install cyfrin/foundry-devops@0.2.2 && forge install smartcontractkit/chainlink-brownie-contracts@1.1.1 && forge install foundry-rs/forge-std@v1.8.2
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
Removed deprecated --no-commit argument when invoking forge install using "make install" command